### PR TITLE
fix: timezone issue of opik

### DIFF
--- a/litellm/integrations/opik/opik.py
+++ b/litellm/integrations/opik/opik.py
@@ -3,6 +3,7 @@ Opik Logger that logs LLM events to an Opik server
 """
 
 import asyncio
+from datetime import timezone
 import json
 import traceback
 from typing import Dict, List
@@ -291,8 +292,8 @@ class OpikLogger(CustomBatchLogger):
                     "project_name": project_name,
                     "id": trace_id,
                     "name": trace_name,
-                    "start_time": start_time.isoformat() + "Z",
-                    "end_time": end_time.isoformat() + "Z",
+                    "start_time": start_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "end_time": end_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
                     "input": input_data,
                     "output": output_data,
                     "metadata": metadata,
@@ -312,8 +313,8 @@ class OpikLogger(CustomBatchLogger):
                 "parent_span_id": parent_span_id,
                 "name": span_name,
                 "type": "llm",
-                "start_time": start_time.isoformat() + "Z",
-                "end_time": end_time.isoformat() + "Z",
+                "start_time": start_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "end_time": end_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
                 "input": input_data,
                 "output": output_data,
                 "metadata": metadata,


### PR DESCRIPTION
## Title

fix: timezone issue of opik. 
the start_time/end_time is local time, we should convert it to utc time

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


